### PR TITLE
Show the preview images in folder README.md's

### DIFF
--- a/2022.05.22.sway_plain/README.md
+++ b/2022.05.22.sway_plain/README.md
@@ -1,0 +1,1 @@
+![Preview image](/2022.05.22.sway_plain/preview.png)

--- a/2022.07.02.i3gaps_blueprint/README.md
+++ b/2022.07.02.i3gaps_blueprint/README.md
@@ -1,0 +1,1 @@
+![image](https://github.com/justmike80386/dots/assets/61964090/21e7632b-5f8e-4e99-b8ae-2d98eb851fd6)


### PR DESCRIPTION
I think it would be nicer to include the theme previews in their respective folders README.md's! The choice is yours though, of course. 